### PR TITLE
v2.2

### DIFF
--- a/Bus/BusInfoFetcher.m
+++ b/Bus/BusInfoFetcher.m
@@ -19,13 +19,14 @@
 
 @interface BusInfoFetcher()
 
-+ ( NSString * ) sectionTitleForDateTime: ( NSDate * ) serviceDateTime;
-
 + ( NSURLSessionTask * ) getAllBusesForStopUsingAPI: ( NSString * ) stopID
                                   completionHandler: ( void ( ^ ) ( NSMutableArray * allBuses ) ) handler;
 
 + ( NSURLSessionTask * ) getAllBusesForStopUsingScraper: ( NSString * ) stopID
                                       completionHandler: ( void ( ^ ) ( NSMutableArray * allBuses ) ) handler;
+
++ ( NSString * ) sectionTitleForDateTime: ( NSDate * ) serviceDateTime;
++ ( NSString * ) safeTrim:                ( id       ) object;
 
 @end
 
@@ -132,8 +133,7 @@
 
         if ( error == nil && services != nil )
         {
-            NSCharacterSet * whitespace              = [ NSCharacterSet whitespaceAndNewlineCharacterSet ];
-            NSDate         * previousServiceDateTime = nil;
+            NSDate * previousServiceDateTime = nil;
 
             // Process the JSON results into a higher level array of objects.
             // Example of a service entry in the dictionary, noting the entry
@@ -152,7 +152,7 @@
             //   "AimedArrival":"2018-05-05T19:30:00+12:00",
             //   "AimedDeparture":"2018-05-05T19:30:00+12:00",
             //   "VehicleFeature":"lowFloor",
-            //   "DepartureStatus":"onTime",
+            //   "DepartureStatus":"onTime",  (or e.g. "cancelled")
             //   "ExpectedDeparture":"2018-05-05T19:31:48+12:00",
             //   "DisplayDeparture": "2018-05-05T19:31:48+12:00",
             //   "DisplayDepartureSeconds":351,
@@ -170,12 +170,12 @@
                 // Try really hard to get a date-time for this service as we
                 // need it for the "Today"/"Tomorrow" etc. section headings.
 
-                NSString * time            = [ service[ @"DisplayDeparture" ] stringByTrimmingCharactersInSet: whitespace ];
+                NSString * time            = [ BusInfoFetcher safeTrim: service[ @"DisplayDeparture" ] ];
                 NSDate   * serviceDateTime = nil;
 
-                if ( time.length == 0 ) time = [ service[ @"ExpectedDeparture" ] stringByTrimmingCharactersInSet: whitespace ];
-                if ( time.length == 0 ) time = [ service[ @"AimedDeparture"    ] stringByTrimmingCharactersInSet: whitespace ];
-                if ( time.length == 0 ) time = [ service[ @"AimedArrival"      ] stringByTrimmingCharactersInSet: whitespace ];
+                if ( time.length == 0 ) time = [ BusInfoFetcher safeTrim: service[ @"ExpectedDeparture" ] ];
+                if ( time.length == 0 ) time = [ BusInfoFetcher safeTrim: service[ @"AimedDeparture"    ] ];
+                if ( time.length == 0 ) time = [ BusInfoFetcher safeTrim: service[ @"AimedArrival"      ] ];
 
                 if ( time.length > 0 )
                 {
@@ -234,25 +234,24 @@
                     ];
                 }
 
-                NSNumber * isRealtime    = service[ @"IsRealtime" ];
-                NSString * name          = service[ @"DestinationStopName" ];
-                NSString * number        = service[ @"Service" ][ @"TrimmedCode" ];
-                NSString * timetablePath = service[ @"Service" ][ @"Link" ];
+                NSNumber * isRealtime      = service[ @"IsRealtime" ];
+                NSString * departureStatus = [ BusInfoFetcher safeTrim: service[ @"DepartureStatus"     ] ];
+                NSString * name            = [ BusInfoFetcher safeTrim: service[ @"DestinationStopName" ] ];
+                NSString * number          = [ BusInfoFetcher safeTrim: service[ @"Service" ][ @"TrimmedCode" ] ];
+                NSString * timetablePath   = [ BusInfoFetcher safeTrim: service[ @"Service" ][ @"Link"        ] ];
 
-                name          = [ name          stringByTrimmingCharactersInSet: whitespace ];
-                number        = [ number        stringByTrimmingCharactersInSet: whitespace ];
-                timetablePath = [ timetablePath stringByTrimmingCharactersInSet: whitespace ];
-
-                if ( name.length == 0 )
+                if ( [ departureStatus isEqualToString: @"cancelled" ] )
                 {
-                    name = service[ @"Service" ][ @"Name" ];
-                    name = [ name stringByTrimmingCharactersInSet: whitespace ];
+                    name = @"CANCELLED"; // Match web scraper
+                }
+                else if ( name.length == 0 )
+                {
+                    name = [ BusInfoFetcher safeTrim: service[ @"Service" ][ @"Name" ] ];
                 }
 
                 if ( number.length == 0 )
                 {
-                    number = service[ @"Service" ][ @"Code" ];
-                    number = [ number stringByTrimmingCharactersInSet: whitespace ];
+                    number = [ BusInfoFetcher safeTrim: service[ @"Service" ][ @"Code" ] ];
                 }
 
                 NSDictionary * routeColours = [ RouteColours colours ];
@@ -439,8 +438,6 @@
 
         for ( HTMLElement * service in services )
         {
-            NSCharacterSet * whitespace = [ NSCharacterSet whitespaceAndNewlineCharacterSet ];
-
             // From October 2015:
             //
             // Added in the ability to define section tables by detecting the
@@ -458,7 +455,7 @@
             if ( [ rowClass isEqualToString: @"rowDivider" ] )
             {
                 HTMLElement * cell         = [ service firstNodeMatchingSelector: @"td" ];
-                NSString    * sectionTitle = [ cell.textContent stringByTrimmingCharactersInSet: whitespace ];
+                NSString    * sectionTitle = [ BusInfoFetcher safeTrim: cell.textContent ];
 
                 if ( [ sectionTitle length ] )
                 {
@@ -539,7 +536,7 @@
 
             if ( numberLink.textContent )
             {
-                number = [ numberLink.textContent stringByTrimmingCharactersInSet: whitespace ];
+                number = [ BusInfoFetcher safeTrim: numberLink.textContent ];
             }
 
             // From October 2015:
@@ -583,7 +580,7 @@
 
             HTMLElement * infoElt       = [ service firstNodeMatchingSelector: @"a.rt-service-destination" ];
             NSString    * timetablePath = [ infoElt.attributes valueForKey: @"href" ]; // Relative path, not absolute URL
-            NSString    * name          = [ infoElt.textContent stringByTrimmingCharactersInSet: whitespace ];
+            NSString    * name          = [ BusInfoFetcher safeTrim: infoElt.textContent ];
 
             // 2016-04-04 (ADH): A recent MetLink fault on their end was to
             // omit names. This looks really odd. So if there's no name, just
@@ -615,8 +612,8 @@
             // HTMLElement * etaElt  = [ service firstNodeMatchingSelector: @"td.time span.till"   ];
             // HTMLElement * timeElt = [ service firstNodeMatchingSelector: @"td.time span.actual" ];
 
-            NSString * eta  = [  etaElt.textContent stringByTrimmingCharactersInSet: whitespace ];
-            NSString * time = [ timeElt.textContent stringByTrimmingCharactersInSet: whitespace ];
+            NSString * eta  = [ BusInfoFetcher safeTrim:  etaElt.textContent ];
+            NSString * time = [ BusInfoFetcher safeTrim: timeElt.textContent ];
 
             if ( number && name && ( time || eta ) )
             {
@@ -738,6 +735,30 @@
         [ formatter setDateFormat: @"eeee" ];
 
         return [ formatter stringFromDate: serviceDateTime ];
+    }
+}
+
+// If reading something that might return either an NSString or "nil",
+// calling methods such as -stringByTrimmingCharactersInSet: on the
+// object is safe. If however you might get NSNull rather than true
+// "nil", you'd be sending an unrecognised selector, resulting in a
+// crash. The JSON parser can do this; the HTML parser might.
+//
+// Call here to trim white space off a string that might otherwise be
+// "nil" or "NSNull". Always returns the trimmed string or "nil".
+//
++ ( NSString * ) safeTrim: ( id ) object
+{
+    if ( [ object isEqual: [ NSNull null ] ] )
+    {
+        return nil;
+    }
+    else
+    {
+        NSString       * string     = ( NSString * ) object;
+        NSCharacterSet * whitespace = [ NSCharacterSet whitespaceAndNewlineCharacterSet ];
+
+        return [ string stringByTrimmingCharactersInSet: whitespace ];
     }
 }
 

--- a/Bus/BusInfoFetcher.m
+++ b/Bus/BusInfoFetcher.m
@@ -72,11 +72,13 @@
 {
     if ( useWebScraper == YES )
     {
+        NSLog( @"Fetching bus information for %@ by web scraper", stopID );
         return [ self getAllBusesForStopUsingScraper: stopID
                                    completionHandler: handler ];
     }
     else
     {
+        NSLog( @"Fetching bus information for %@ by API", stopID );
         return [ self getAllBusesForStopUsingAPI: stopID
                                completionHandler: handler ];
     }

--- a/Bus/DataManager.m
+++ b/Bus/DataManager.m
@@ -1133,16 +1133,23 @@
 
     // First update local records.
 
+NSLog(@"1");
+
     NSUserDefaults         * defaults           = NSUserDefaults.standardUserDefaults;
     BOOL                     oldShowSectionFlag = self.shouldShowSectionHeader;
     BOOL                     preferredDidChange = NO;
     NSManagedObject        * object             = [ DataManager.dataManager findFavouriteStopByID: stopID ];
     NSManagedObjectContext * context            = self.managedObjectContextLocal;
 
+NSLog(@"2 %@ %d %d %@ %@",defaults,oldShowSectionFlag,
+      preferredDidChange,object,context);
+
     if ( object == nil )
     {
         NSString * newStopDescription = ( stopDescription == nil ) ? [ stopID copy ]             : stopDescription;
         NSNumber * newPreferred       = ( preferred       == nil ) ? STOP_IS_NOT_PREFERRED_VALUE : preferred;
+
+NSLog(@"3A %@ %@ %@",newStopDescription,newPreferred,object);
 
         object =
         [
@@ -1150,24 +1157,32 @@
                                          inManagedObjectContext: context
         ];
 
+NSLog(@"3A %@ %@ %@",newStopDescription,newPreferred,object);
+
         [ object setValue: stopID             forKey: @"stopID" ];
         [ object setValue: newStopDescription forKey: @"stopDescription" ];
         [ object setValue: newPreferred       forKey: @"preferred"       ];
+
+NSLog(@"4A");
     }
     else
     {
         NSNumber * oldPreferred = [ object valueForKey: @"preferred" ];
-
+NSLog(@"3B %@, %@", preferred, oldPreferred);
         preferredDidChange = ( preferred == nil || [ preferred isEqualToNumber: oldPreferred ] ) ? NO : YES;
 
         if ( stopDescription != nil ) [ object setValue: stopDescription forKey: @"stopDescription" ];
         if ( preferred       != nil ) [ object setValue: preferred       forKey: @"preferred"       ];
+
+NSLog(@"4B");
     }
 
     NSError * error = nil;
 
+NSLog(@"5 Save");
     if ( ! [ context save: &error ] )
     {
+NSLog(@"6 Error");
         [ self handleError: error
                  withTitle: NSLocalizedString( @"Could not change 'preferred' stop setting", "Error message shown when changing the 'preferred' setting fails" ) ];
 
@@ -1179,6 +1194,7 @@
     // table redraw.
     //
     BOOL newShowSectionFlag = self.shouldShowSectionHeader;
+NSLog(@"6 Send data changed, pref dif change %d %d", oldShowSectionFlag != newShowSectionFlag, preferredDidChange);
     if ( oldShowSectionFlag != newShowSectionFlag ) [ self sendDataHasChangedNotification ];
 
     if ( preferredDidChange )
@@ -1219,6 +1235,8 @@
         @"Could not save changes in iCloud",
         @"Error message shown when trying to save favourite stop changes to iCloud"
     );
+
+NSLog(@"7 Con %@ DB %@ zon %@ rec %@",container,database,zoneID,recordID);
 
     [ self spinnerOn ];
 

--- a/Bus/DataManager.m
+++ b/Bus/DataManager.m
@@ -1133,23 +1133,16 @@
 
     // First update local records.
 
-NSLog(@"1");
-
     NSUserDefaults         * defaults           = NSUserDefaults.standardUserDefaults;
     BOOL                     oldShowSectionFlag = self.shouldShowSectionHeader;
     BOOL                     preferredDidChange = NO;
     NSManagedObject        * object             = [ DataManager.dataManager findFavouriteStopByID: stopID ];
     NSManagedObjectContext * context            = self.managedObjectContextLocal;
 
-NSLog(@"2 %@ %d %d %@ %@",defaults,oldShowSectionFlag,
-      preferredDidChange,object,context);
-
     if ( object == nil )
     {
         NSString * newStopDescription = ( stopDescription == nil ) ? [ stopID copy ]             : stopDescription;
         NSNumber * newPreferred       = ( preferred       == nil ) ? STOP_IS_NOT_PREFERRED_VALUE : preferred;
-
-NSLog(@"3A %@ %@ %@",newStopDescription,newPreferred,object);
 
         object =
         [
@@ -1157,32 +1150,24 @@ NSLog(@"3A %@ %@ %@",newStopDescription,newPreferred,object);
                                          inManagedObjectContext: context
         ];
 
-NSLog(@"3A %@ %@ %@",newStopDescription,newPreferred,object);
-
         [ object setValue: stopID             forKey: @"stopID" ];
         [ object setValue: newStopDescription forKey: @"stopDescription" ];
         [ object setValue: newPreferred       forKey: @"preferred"       ];
-
-NSLog(@"4A");
     }
     else
     {
         NSNumber * oldPreferred = [ object valueForKey: @"preferred" ];
-NSLog(@"3B %@, %@", preferred, oldPreferred);
+
         preferredDidChange = ( preferred == nil || [ preferred isEqualToNumber: oldPreferred ] ) ? NO : YES;
 
         if ( stopDescription != nil ) [ object setValue: stopDescription forKey: @"stopDescription" ];
         if ( preferred       != nil ) [ object setValue: preferred       forKey: @"preferred"       ];
-
-NSLog(@"4B");
     }
 
     NSError * error = nil;
 
-NSLog(@"5 Save");
     if ( ! [ context save: &error ] )
     {
-NSLog(@"6 Error");
         [ self handleError: error
                  withTitle: NSLocalizedString( @"Could not change 'preferred' stop setting", "Error message shown when changing the 'preferred' setting fails" ) ];
 
@@ -1194,7 +1179,7 @@ NSLog(@"6 Error");
     // table redraw.
     //
     BOOL newShowSectionFlag = self.shouldShowSectionHeader;
-NSLog(@"6 Send data changed, pref dif change %d %d", oldShowSectionFlag != newShowSectionFlag, preferredDidChange);
+
     if ( oldShowSectionFlag != newShowSectionFlag ) [ self sendDataHasChangedNotification ];
 
     if ( preferredDidChange )
@@ -1235,8 +1220,6 @@ NSLog(@"6 Send data changed, pref dif change %d %d", oldShowSectionFlag != newSh
         @"Could not save changes in iCloud",
         @"Error message shown when trying to save favourite stop changes to iCloud"
     );
-
-NSLog(@"7 Con %@ DB %@ zon %@ rec %@",container,database,zoneID,recordID);
 
     [ self spinnerOn ];
 

--- a/Bus/DataManager.m
+++ b/Bus/DataManager.m
@@ -30,6 +30,10 @@
     //
     @property ( strong ) NSOperationQueue * cloudOperationsQueue;
 
+    // Main awaken operation we'll run on this queue.
+    //
+    @property ( strong ) NSBlockOperation * awakenOperation;
+
     // The above queue has the major awaken operation performed in it, but we
     // also do per-record saves using that queue too. This means that if one
     // save is delayed for some reason (e.g. rate limits) but then the same
@@ -148,27 +152,32 @@
 //
 - ( void ) awakenAllStores
 {
-    NSUserDefaults * defaults = NSUserDefaults.standardUserDefaults;
-
     // If we're already running an 'awaken' job, cancel it. This later one
     // takes priority.
     //
     [ self.cloudOperationsQueue cancelAllOperations ];
 
-    // Need to define the block operation object up here, so that inside the
-    // block we can reference this and check if "we" have been cancelled.
+    // (Re)define the operation block (any old operation now being cancelled)
+    // allowing any old one to be garbage collected.
     //
-    NSBlockOperation * awakenOperation = [ [ NSBlockOperation alloc ] init ];
-    __weak NSBlockOperation * thisOperation = awakenOperation;
+    self.awakenOperation = [ [ NSBlockOperation alloc ] init ];
+
+    // Avoid potential retain cycles.
+    //
+    __weak NSBlockOperation * thisOperation = self.awakenOperation;
 
     // Define the one and only block that we'll pass to an NSBlockOperation
     // instance and then place on the queue at the very end of this method.
     //
     id awakenOperationBlock = ^ ( void )
     {
+        DataManager * dataManager = [ DataManager dataManager ];
+
         [
             [ CKContainer defaultContainer ] accountStatusWithCompletionHandler: ^ ( CKAccountStatus accountStatus, NSError * error )
             {
+                NSUserDefaults * defaults = NSUserDefaults.standardUserDefaults;
+
                 if ( thisOperation.cancelled ) return;
 
                 if ( accountStatus == CKAccountStatusNoAccount )
@@ -180,12 +189,11 @@
                     if ( [ defaults boolForKey: HAVE_SHOWN_ICLOUD_SIGNIN_WARNING ] != YES )
                     {
                         [ defaults setBool: YES forKey: HAVE_SHOWN_ICLOUD_SIGNIN_WARNING ];
-
                         if ( thisOperation.cancelled ) return;
 
-                        [ self showMessage: @"Sign in to iCloud to synchronise favourites between devices.\n\nOtherwise, Bus Panda can still save favourites but only on this device."
-                                 withTitle: @"Not signed in to iCloud"
-                                 andButton: @"Got it!" ];
+                        [ dataManager showMessage: @"Sign in to iCloud to synchronise favourites between devices.\n\nOtherwise, Bus Panda can still save favourites but only on this device."
+                                        withTitle: @"Not signed in to iCloud"
+                                        andButton: @"Got it!" ];
                     }
                 }
                 else if ( accountStatus != CKAccountStatusAvailable )
@@ -195,9 +203,9 @@
                     [ defaults setBool: NO forKey: ICLOUD_IS_AVAILABLE ];
                     if ( thisOperation.cancelled ) return;
 
-                    [ self showMessage: @"iCloud is not available, either due to parental controls or an error. Bus Panda will not be able to synchronise favourite stops with your other devices."
-                             withTitle: @"Cannot use iCloud"
-                             andButton: @"Got it!" ];
+                    [ dataManager showMessage: @"iCloud is not available, either due to parental controls or an error. Bus Panda will not be able to synchronise favourite stops with your other devices."
+                                    withTitle: @"Cannot use iCloud"
+                                    andButton: @"Got it!" ];
                 }
                 else
                 {
@@ -261,7 +269,7 @@
                                     // the new local storage with CloudKit sync.
 
                                     if ( thisOperation.cancelled ) return;
-                                    [ self managedObjectContextRemote ];
+                                    [ dataManager managedObjectContextRemote ];
                                 }
                             };
 
@@ -286,10 +294,10 @@
 
                                 if ( object != nil )
                                 {
-                                    [ self addOrEditFavourite: [ object valueForKey: @"stopID"          ]
-                                           settingDescription: [ object valueForKey: @"stopDescription" ]
-                                             andPreferredFlag: [ object valueForKey: @"preferred"       ]
-                                            includingCloudKit: YES ];
+                                    [ dataManager addOrEditFavourite: [ object valueForKey: @"stopID"          ]
+                                                  settingDescription: [ object valueForKey: @"stopDescription" ]
+                                                    andPreferredFlag: [ object valueForKey: @"preferred"       ]
+                                                   includingCloudKit: YES ];
                                 }
                             }
 
@@ -297,8 +305,8 @@
                             // in the local user default records and therefore
                             // already subject to updates.
                             //
-                            [ self fetchRecentChangesWithCompletionBlock: completionBlock
-                                                ignoringPriorChangeToken: YES ];
+                            [ dataManager fetchRecentChangesWithCompletionBlock: completionBlock
+                                                       ignoringPriorChangeToken: YES ];
 #endif
 
                             // With that underway, we can set up our subscription to
@@ -371,11 +379,11 @@
     // As per comments far above :-) now finally add the big block we just
     // defined as a (cancelleable) operation that'll get run when iOS is ready.
     //
-    awakenOperation.completionBlock = ^ ( void ) { [ self spinnerOff ]; };
+    self.awakenOperation.completionBlock = ^ ( void ) { [ [ DataManager dataManager ] spinnerOff ]; };
     [ self spinnerOn ];
 
-    [ awakenOperation addExecutionBlock: awakenOperationBlock ];
-    [ self.cloudOperationsQueue addOperation: awakenOperation ];
+    [ self.awakenOperation addExecutionBlock: awakenOperationBlock ];
+    [ self.cloudOperationsQueue addOperation: self.awakenOperation ];
 }
 
 #pragma mark - Support utilities

--- a/Bus/Info.plist
+++ b/Bus/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201807161821</string>
+	<string>201809082227</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Bus/Info.plist
+++ b/Bus/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201809082227</string>
+	<string>201809112052</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/watchkit Extension/Info.plist
+++ b/watchkit Extension/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201809082227</string>
+	<string>201809112052</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/watchkit Extension/Info.plist
+++ b/watchkit Extension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201807161821</string>
+	<string>201809082227</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/watchkit/Info.plist
+++ b/watchkit/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201809082227</string>
+	<string>201809112052</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/watchkit/Info.plist
+++ b/watchkit/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>201807161821</string>
+	<string>201809082227</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Bug fixes:

* Attempts to resolve intermittent pthread abort at startup during CloudKit operations
* "Shorten names" label now once again reliably causes a display update in the favourite stops table
* API scraper understands and displays cancelled services
* Web scraper results always shown on top of API results instead of attempting to merge; simpler, sort-of-faster and avoids the possible service duplications at the join point, but does mean the user might see the due numbers change if the two methods disagree
* Auto-refresh of service view every 60 seconds
* Consistent web scraper vs API section titles now
* Survives JSON parser NSNull where string values were expected; would previously have crashed
